### PR TITLE
Adjust permissions guide layout for small screens

### DIFF
--- a/ScienceJournal/UI/PermissionsGuideViewController.swift
+++ b/ScienceJournal/UI/PermissionsGuideViewController.swift
@@ -178,7 +178,9 @@ class PermissionsGuideViewController: OnboardingViewController {
     headerTitle.translatesAutoresizingMaskIntoConstraints = false
     headerTopConstraint = headerTitle.topAnchor.constraint(equalTo: headerImage.bottomAnchor,
                                                            constant: Metrics.headerTopPaddingNarrow)
+    headerTopConstraint?.priority = .defaultHigh
     headerTopConstraint?.isActive = true
+
     headerTitle.textColor = ArduinoColorPalette.goldPalette.tint400
     headerTitle.font = ArduinoTypography.boldFont(forSize: 28)
     headerTitle.textAlignment = .center
@@ -186,6 +188,8 @@ class PermissionsGuideViewController: OnboardingViewController {
     headerTitle.numberOfLines = 0
     headerTitle.leadingAnchor.constraint(equalTo: wrappingView.readableContentGuide.leadingAnchor).isActive = true
     headerTitle.trailingAnchor.constraint(equalTo: wrappingView.readableContentGuide.trailingAnchor).isActive = true
+    headerTitle.topAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: headerImage.bottomAnchor,
+                                     multiplier: 1).isActive = true
 
     // Shared label config.
     [initialMessage, finalMessage, notificationsMessage, microphoneMessage, cameraMessage,
@@ -233,11 +237,15 @@ class PermissionsGuideViewController: OnboardingViewController {
 
     // Shared button config.
     [startButton, completeButton, continueButton].forEach {
+      $0.contentEdgeInsets = UIEdgeInsets(top: 0,
+                                          left: Metrics.buttonHeight/2.0,
+                                          bottom: 0,
+                                          right: Metrics.buttonHeight/2.0)
       wrappingView.addSubview($0)
       $0.translatesAutoresizingMaskIntoConstraints = false
       $0.centerXAnchor.constraint(equalTo: wrappingView.centerXAnchor).isActive = true
       $0.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight).isActive = true
-      $0.widthAnchor.constraint(equalToConstant: Metrics.buttonWidth).isActive = true
+      $0.widthAnchor.constraint(greaterThanOrEqualToConstant: Metrics.buttonWidth).isActive = true
       $0.setBackgroundImage(UIImage(named: "rounded_button_background"), for: .normal)
       $0.titleLabel?.font = ArduinoTypography.boldFont(forSize: 16)
       $0.setTitleColor(view.backgroundColor, for: .normal)
@@ -270,7 +278,11 @@ class PermissionsGuideViewController: OnboardingViewController {
     continueTopConstraint =
         continueButton.topAnchor.constraint(equalTo: notificationsMessage.bottomAnchor,
                                             constant: Metrics.buttonSpacing)
+    continueTopConstraint?.priority = .defaultHigh-1
     continueTopConstraint?.isActive = true
+
+    startButton.topAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: initialMessage.bottomAnchor,
+                                     multiplier: 1).isActive = true
 
     // Step counter
     configureStepsImageView()
@@ -278,6 +290,7 @@ class PermissionsGuideViewController: OnboardingViewController {
 
   private func configureArduinoLogo() {
     logoImageView.translatesAutoresizingMaskIntoConstraints = false
+    logoImageView.contentMode = .scaleAspectFit
     wrappingView.addSubview(logoImageView)
     logoImageView.centerXAnchor.constraint(equalTo: wrappingView.centerXAnchor).isActive = true
     logoImageView.bottomAnchor.constraint(equalTo: wrappingView.safeAreaLayoutGuide.bottomAnchor,
@@ -317,10 +330,13 @@ class PermissionsGuideViewController: OnboardingViewController {
   private func configureStepsImageView() {
     stepsImageView.isHidden = true
     stepsImageView.translatesAutoresizingMaskIntoConstraints = false
+    stepsImageView.setContentCompressionResistancePriority(.required, for: .vertical)
     wrappingView.addSubview(stepsImageView)
     stepsImageView.centerXAnchor.constraint(equalTo: wrappingView.centerXAnchor).isActive = true
     stepsImageView.bottomAnchor.constraint(equalTo: wrappingView.safeAreaLayoutGuide.bottomAnchor,
                                            constant: -Metrics.arduinoLogoBottomPadding).isActive = true
+    stepsImageView.topAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: continueButton.bottomAnchor,
+                                        multiplier: 1.0).isActive = true
   }
 
   // Updates constraints for labels. Used in rotation to ensure the best fit for various screen
@@ -558,6 +574,7 @@ class PermissionsGuideViewController: OnboardingViewController {
     continueTopConstraint?.isActive = false
     continueTopConstraint = continueButton.topAnchor.constraint(equalTo: label.bottomAnchor,
                                                                 constant: Metrics.buttonSpacing)
+    continueTopConstraint?.priority = .defaultHigh-1
     continueTopConstraint?.isActive = true
     continueButton.layoutIfNeeded()
   }


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/bcmi-labs/Science-Journal-iOS/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/bcmi-labs/Science-Journal-iOS/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
This PR fixes #14. 

### Description
I've adjusted some auto layout constraints in order to better fit in small screens. However I cannot guarantee that this will work for every language, as some labels might be too long to fit with this rigid design.

In the future I'd also suggest to remove the permissions request at the first launch, as it doesn't fit well with the iOS HIG. Instead we should ask for permissions on demand, when the user might need them.

Attached you can see screenshots of the fixed layout.

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-09-09 at 11 15 17](https://user-images.githubusercontent.com/467098/92580770-1b456800-f28f-11ea-8e71-a9f43ee674f0.png)

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-09-09 at 11 15 20](https://user-images.githubusercontent.com/467098/92580780-1f718580-f28f-11ea-94c4-9b751342859b.png)

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-09-09 at 11 15 23](https://user-images.githubusercontent.com/467098/92580788-213b4900-f28f-11ea-9735-0d054fc06be8.png)

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-09-09 at 11 15 27](https://user-images.githubusercontent.com/467098/92580794-226c7600-f28f-11ea-9513-5a4416b11589.png)

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-09-09 at 11 15 30](https://user-images.githubusercontent.com/467098/92580801-239da300-f28f-11ea-9029-41a563e0dfc4.png)

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-09-09 at 11 15 32](https://user-images.githubusercontent.com/467098/92580804-24ced000-f28f-11ea-9fd2-d15ec1c2d4d4.png)






