### PR TITLE
Hide whatsGoingOnLabel if not needed

### DIFF
--- a/ScienceJournal/UI/LearnMoreViewController.swift
+++ b/ScienceJournal/UI/LearnMoreViewController.swift
@@ -102,6 +102,10 @@ class LearnMoreViewController: MaterialHeaderViewController {
     scrollView.addSubview(stackView)
     stackView.pinToEdgesOfView(scrollView)
     stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
+
+    if sensor.learnMore == nil || sensor.learnMore!.isEmpty {
+      whatsGoingOnLabel.isHidden = true
+    }
   }
 
   override func accessibilityPerformEscape() -> Bool {
@@ -115,4 +119,10 @@ class LearnMoreViewController: MaterialHeaderViewController {
     dismiss(animated: true)
   }
 
+}
+
+extension Sensor.LearnMore {
+  var isEmpty: Bool {
+    firstParagraph.isEmpty && secondParagraph.isEmpty && imageName.isEmpty
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/bcmi-labs/Science-Journal-iOS/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/bcmi-labs/Science-Journal-iOS/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
This PR fixes #24.

### Description
Some sensors might not have additional information. In such a case there's no need to show a paragraph title in `LearnMoreViewController`. 
