### PR TITLE
Fix trial card header labels alignment

### DIFF
--- a/ScienceJournal/UI/TrialCardHeaderView.swift
+++ b/ScienceJournal/UI/TrialCardHeaderView.swift
@@ -93,6 +93,7 @@ class TrialCardHeaderView: UIView {
     addSubview(titleLabel)
     applyLabelStyles(to: titleLabel)
 
+    titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
     let titleInsets = UIEdgeInsets(top: ExperimentCardView.innerVerticalPadding,
                                    left: ExperimentCardView.innerHorizontalPadding,
@@ -104,6 +105,7 @@ class TrialCardHeaderView: UIView {
     addSubview(durationLabel)
     applyLabelStyles(to: durationLabel)
 
+    durationLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
     durationLabel.translatesAutoresizingMaskIntoConstraints = false
     let durationInsets = UIEdgeInsets(top: ExperimentCardView.innerVerticalPadding,
                                       left: 0,


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/bcmi-labs/Science-Journal-iOS/blob/master/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/bcmi-labs/Science-Journal-iOS/blob/master/CHANGE_LIMITATIONS.md)

### Motivation and Context
This PR fixes #18.

### Description
Both the label had the same content hugging priority. I set them explicitly in order to have a deterministic behavior.