### PR TITLE
Fix unarchive icon in the experiment cell menu

### DIFF
--- a/ScienceJournal/UI/ExperimentsListViewController.swift
+++ b/ScienceJournal/UI/ExperimentsListViewController.swift
@@ -671,6 +671,7 @@ class ExperimentsListViewController: MaterialHeaderViewController, ExperimentSta
   func menuButtonPressedForCell(_ cell: ExperimentsListCell, attachmentButton: UIButton) {
     guard let overview = experimentsListItemsViewController.overview(forCell: cell) else { return }
     let archiveTitle = overview.isArchived ? String.actionUnarchive : String.actionArchive
+    let archiveIcon = overview.isArchived ? UIImage(named: "ic_unarchive") : UIImage(named: "ic_archive")
     let archiveAccessibilityLabel = overview.isArchived ?
         String.actionUnarchiveExperimentContentDescription :
         String.actionArchiveExperimentContentDescription
@@ -693,7 +694,7 @@ class ExperimentsListViewController: MaterialHeaderViewController, ExperimentSta
     // Archive.
     popUpMenu.addAction(PopUpMenuAction(
         title: archiveTitle,
-        icon: UIImage(named: "ic_archive"),
+        icon: archiveIcon,
         accessibilityLabel: archiveAccessibilityLabel) { _ -> Void in
       self.delegate?.experimentsListToggleArchiveStateForExperiment(withID: overview.experimentID)
     })


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CHANGE_LIMITATIONS.md)

### Motivation and Context
When selecting the experiment menu from the experiments list, the archive and unarchive action used the same icon. This fixes #32.

### Description
Now we pick the right icon according with the action.
