### PR TITLE
Add bigger button to onboarding screen

### DIFF
--- a/ScienceJournal/UI/Onboarding/OnboardingPageView.swift
+++ b/ScienceJournal/UI/Onboarding/OnboardingPageView.swift
@@ -377,17 +377,30 @@ class OnboardingButton: UIButton {
     case outline
     case filled
   }
+  
+  enum Size {
+    case small
+    case large
+  }
 
   private var style = Style.outline
+  private var size = Size.small
 
   convenience init(style: Style, title: String) {
+    self.init(style: style, size: .small, title: title)
+  }
+  
+  convenience init(style: Style, size: Size, title: String) {
     self.init(type: .system)
 
+    self.size = size
     self.style = style
 
-    contentEdgeInsets = UIEdgeInsets(top: 4, left: 28, bottom: 4, right: 28)
+    let verticalSpacing:CGFloat = self.size == .small ? 4 : 8
+    contentEdgeInsets = UIEdgeInsets(top: verticalSpacing, left: 28, bottom: verticalSpacing, right: 28)
     setTitle(title, for: .normal)
-    titleLabel?.font = ArduinoTypography.boldFont(forSize: ArduinoTypography.FontSize.XSmall.rawValue)
+    let fontSize = self.size == .small ? ArduinoTypography.FontSize.XSmall : ArduinoTypography.FontSize.Small
+    titleLabel?.font = ArduinoTypography.boldFont(forSize: fontSize.rawValue)
 
     updateStyle()
   }

--- a/ScienceJournal/UI/Onboarding/Pages/OnboardingPage7ViewController.swift
+++ b/ScienceJournal/UI/Onboarding/Pages/OnboardingPage7ViewController.swift
@@ -56,6 +56,7 @@ class OnboardingPage7ViewController: OnboardingPageViewController {
     stackView.addArrangedSubview(OnboardingSpacer())
 
     let button = OnboardingButton(style: .filled,
+                                  size: .large,
                                   title: String.onboardingFinishButton)
     button.addTarget(self, action: #selector(finish(_:)), for: .touchUpInside)
 


### PR DESCRIPTION
### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CHANGE_LIMITATIONS.md)

### Motivation and Context
Primary CTA button in onboarding should be larger to make it easier to tap.

### Description
Added a size attribute to the button class
Made the button bigger on the last onboarding page
