### PR TITLE
Fix camera permission

### DIFF
--- a/ScienceJournal/CaptureSession/CameraAccessHandler.swift
+++ b/ScienceJournal/CaptureSession/CameraAccessHandler.swift
@@ -19,23 +19,27 @@ import AVFoundation
 /// Handles checking and asking for camera access permission.
 class CameraAccessHandler {
 
+  /// Returns `true` if the user authorized access to the device camera.
+  static var hasGrantedAccess: Bool {
+    AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+  }
+
   /// Checks the permissions status of the camera, and requests access if needed.
   ///
   /// - Parameter requestCompletion: Called with the status of the permission (true if granted),
-  ///              when access had to be requested.
-  /// - Returns: Whether or not permission has been granted.
-  static func checkForPermission(requestCompletion: ((Bool) -> Void)? = nil) -> Bool {
+  static func checkForPermission(requestCompletion: ((Bool) -> Void)? = nil) {
     let authStatus = AVCaptureDevice.authorizationStatus(for: .video)
     switch authStatus {
-    case .denied, .restricted: return false
-    case .authorized: return true
+    case .denied, .restricted: requestCompletion?(false)
+    case .authorized: requestCompletion?(true)
     case .notDetermined:
       // Prompt user for the permission to use the camera.
       AVCaptureDevice.requestAccess(for: .video) { granted in
-        requestCompletion?(granted)
+        DispatchQueue.main.async {
+          requestCompletion?(granted)
+        }
       }
-      return false
-    @unknown default: return false
+    @unknown default: requestCompletion?(false)
     }
   }
 

--- a/ScienceJournal/CaptureSession/CaptureSessionInterruptionObserver.swift
+++ b/ScienceJournal/CaptureSession/CaptureSessionInterruptionObserver.swift
@@ -46,29 +46,25 @@ class CaptureSessionInterruptionObserver {
   /// recording, during which the camera cannot be used.
   var isCameraUseAllowed: Bool {
     return !isCaptureSessionInterrupted && !isBrightnessSensorInUse &&
-        CameraAccessHandler.checkForPermission()
-  }
-
-  var cameraAvailability: CameraAvailability {
-
-    if isBrightnessSensorInUse {
-      return .blockedByBrightnessSensor
-    }
-
-    if isCaptureSessionInterrupted {
-      return .captureInterrupted
-    }
-
-    // Note: this check will request perms if they are not determined,
-    // so it's not a 1:1 match with permissions denied
-    if CameraAccessHandler.checkForPermission() {
-      return .available
-    } else {
-      return .permissionsDenied
-    }
+        CameraAccessHandler.hasGrantedAccess
   }
 
   // MARK: - Public
+  func checkCameraAvailability(handler: @escaping (CameraAvailability) -> Void) {
+    guard !isBrightnessSensorInUse else {
+      handler(.blockedByBrightnessSensor)
+      return
+    }
+
+    guard !isCaptureSessionInterrupted else {
+      handler(.captureInterrupted)
+      return
+    }
+
+    CameraAccessHandler.checkForPermission {
+      $0 ? handler(.available) : handler(.permissionsDenied)
+    }
+  }
 
   // MARK: - Private
 

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -1752,17 +1752,21 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
   }
 
   func cameraButtonPressed() {
-    switch CaptureSessionInterruptionObserver.shared.cameraAvailability {
-    case .permissionsDenied:
-      showCameraPermissionsDeniedAlert()
-    case .blockedByBrightnessSensor:
-      showSnackbar(withMessage: String.inputCameraBlockedByBrightnessSensor,
-                   category: nil,
-                   actionTitle: String.actionOk,
-                   actionHandler: nil
-      )
-    default: // Handles .available and .captureInterrupted
-      present(cameraImageProvider.cameraViewController, animated: true)
+    CaptureSessionInterruptionObserver.shared.checkCameraAvailability { [weak self] in
+      guard let self = self else { return }
+
+      switch $0 {
+      case .permissionsDenied:
+        self.showCameraPermissionsDeniedAlert()
+      case .blockedByBrightnessSensor:
+        showSnackbar(withMessage: String.inputCameraBlockedByBrightnessSensor,
+                     category: nil,
+                     actionTitle: String.actionOk,
+                     actionHandler: nil
+        )
+      default: // Handles .available and .captureInterrupted
+        self.present(self.cameraImageProvider.cameraViewController, animated: true)
+      }
     }
   }
 

--- a/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
+++ b/ScienceJournal/UI/ExperimentCoordinatorViewController.swift
@@ -1157,20 +1157,22 @@ class ExperimentCoordinatorViewController: MaterialHeaderViewController, DrawerP
       updateAppBarBackgroundColor()
     }
 
-    let isCameraAllowed = CaptureSessionInterruptionObserver.shared.isCameraUseAllowed
-    // Update the camera tab icon.
-    drawerVC?.isCameraItemEnabled = isCameraAllowed
-    if drawerVC?.currentViewController is CameraViewController {
-      // Update the camera disabled view and start the capture session if the camera is currently
-      // visible.
-      drawerVC?.cameraViewController.photoCapturer.startCaptureSessionIfNecessary()
-      drawerVC?.cameraViewController.updateDisabledView(forCameraUseAllowed: isCameraAllowed)
-    }
-    // Update the recording progress bar.
-    if isRecording {
-      drawerVC?.drawerView.recordingBar.startAnimating()
-    } else {
-      drawerVC?.drawerView.recordingBar.stopAnimating()
+    if let drawerVC = drawerVC {
+      let isCameraAllowed = CaptureSessionInterruptionObserver.shared.isCameraUseAllowed
+      // Update the camera tab icon.
+      drawerVC.isCameraItemEnabled = isCameraAllowed
+      if drawerVC.currentViewController is CameraViewController {
+        // Update the camera disabled view and start the capture session if the camera is currently
+        // visible.
+        drawerVC.cameraViewController.photoCapturer.startCaptureSessionIfNecessary()
+        drawerVC.cameraViewController.updateDisabledView(forCameraUseAllowed: isCameraAllowed)
+      }
+      // Update the recording progress bar.
+      if isRecording {
+        drawerVC.drawerView.recordingBar.startAnimating()
+      } else {
+        drawerVC.drawerView.recordingBar.stopAnimating()
+      }
     }
   }
 

--- a/ScienceJournal/UI/PhotoCapturer.swift
+++ b/ScienceJournal/UI/PhotoCapturer.swift
@@ -99,10 +99,14 @@ class PhotoCapturer: NSObject, AVCapturePhotoCaptureDelegate {
 
   /// The permissions state of the capturer.
   var isCameraPermissionGranted: Bool {
-    let granted = CameraAccessHandler.checkForPermission { (permission) in
+    if CameraAccessHandler.hasGrantedAccess {
+      return true
+    }
+
+    CameraAccessHandler.checkForPermission { (permission) in
       self.delegate?.photoCapturerCameraPermissionsDidChange(accessGranted: permission)
     }
-    return granted
+    return false
   }
 
   /// Switches to a camera.

--- a/ScienceJournal/UI/TrialDetailViewController.swift
+++ b/ScienceJournal/UI/TrialDetailViewController.swift
@@ -1763,17 +1763,21 @@ class TrialDetailViewController: MaterialHeaderViewController,
   }
 
   func cameraButtonPressed() {
-    switch CaptureSessionInterruptionObserver.shared.cameraAvailability {
-    case .permissionsDenied:
-      showCameraPermissionsDeniedAlert()
-    case .blockedByBrightnessSensor:
-      showSnackbar(withMessage: String.inputCameraBlockedByBrightnessSensor,
-                   category: nil,
-                   actionTitle: String.actionOk,
-                   actionHandler: nil
-      )
-    default: // Handles .available and .captureInterrupted
-      present(cameraImageProvider.cameraViewController, animated: true)
+    CaptureSessionInterruptionObserver.shared.checkCameraAvailability { [weak self] in
+      guard let self = self else { return }
+
+      switch $0 {
+      case .permissionsDenied:
+        self.showCameraPermissionsDeniedAlert()
+      case .blockedByBrightnessSensor:
+        showSnackbar(withMessage: String.inputCameraBlockedByBrightnessSensor,
+                     category: nil,
+                     actionTitle: String.actionOk,
+                     actionHandler: nil
+        )
+      default: // Handles .available and .captureInterrupted
+        self.present(self.cameraImageProvider.cameraViewController, animated: true)
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CHANGE_LIMITATIONS.md)

### Motivation and Context
The app asks for camera permission after starting a recording for the first time. As it's not the right time to do that I made a refactor to fix it.

### Description
The current implementation asks for camera permission just to know if the camera access is available. I split the two use cases in `CameraAccessHandler`:
```Swift
static var hasGrantedAccess: Bool
```
returns the state without asking for the permission the first time.
```Swift
static func checkForPermission(requestCompletion: ((Bool) -> Void)? = nil)
```
checks the permission state and request for it if it's `.notDetermined`. The result is handled via a callback that can be asynchronous.

Then I modified all the points in the app where these APIs were used.
