### PR TITLE
Remove action from snackbar when adding a note

### DIFF
--- a/ScienceJournal/Strings/ScienceJournalStrings.swift
+++ b/ScienceJournal/Strings/ScienceJournalStrings.swift
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020 Google LLC. All Rights Reserved.
+ *  Copyright 2021 Google LLC. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/ScienceJournal/UI/UserFlowViewController.swift
+++ b/ScienceJournal/UI/UserFlowViewController.swift
@@ -676,10 +676,8 @@ class UserFlowViewController: UIViewController, ExperimentsListViewControllerDel
     showSnackbar(
       withMessage: String.actionAreaRecordingNoteSavedMessage,
       category: nil,
-      actionTitle: String.actionAreaRecordingNoteSavedViewButton,
-      actionHandler: {
-        self.actionAreaController?.revealMaster()
-    })
+      actionTitle: nil,
+      actionHandler: nil)
   }
 
   func detailViewControllerDidDeleteNote(_ deletedDisplayNote: DisplayNote) {


### PR DESCRIPTION
<!-- Thanks for contributing to Science Journal iOS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CHANGE_LIMITATIONS.md)

### Motivation and Context
When a note has been added to an experiment a snackbar that informs the user is shown. It has a "view" action that brings
the user to the main experiment screen. Sometimes tapping on it may crash the app, depending on which screen the user is actually using (e.g. if the user is already in the main experiment screen).

### Description
While a message that informs users about the success of their action is good, a "view" action might be useless at that point. For this I removed the callback that did nothing really useful.