### PR TITLE
Fix incorrect Input 2 icon

### DIFF
--- a/ScienceJournal/BLEArduino/MKRWiFi1010/Sensors/BLEScienceKitInput2Sensor.swift
+++ b/ScienceJournal/BLEArduino/MKRWiFi1010/Sensors/BLEScienceKitInput2Sensor.swift
@@ -24,7 +24,7 @@ struct BLEScienceKitInput2Sensor: BLEArduinoSensor {
 
   var name: String { "input_2".localized }
 
-  var iconName: String { "ic_sensor_input_2_filled" }
+  var iconName: String { "ic_sensor_input_2" }
   
   var filledIconName: String { "ic_sensor_input_2_filled" }
 


### PR DESCRIPTION
### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CHANGE_LIMITATIONS.md)

### Motivation and Context
Input 2 icon is displayed in filled version but should appear as non-filled version in the sensor settings.

### Description
Changes incorrect identifier for non-filled version
This PR fixes this. See attached screenshot.
![IMG_727FEC53F99A-1](https://user-images.githubusercontent.com/1326220/104158289-4d0d3d80-53ed-11eb-802e-a4de28d312a5.jpeg)
