### PR TITLE
Add resistance sensor

### DIFF
--- a/ScienceJournal.xcodeproj/project.pbxproj
+++ b/ScienceJournal.xcodeproj/project.pbxproj
@@ -692,6 +692,7 @@
 		F36675A224FE5F5E004E567D /* Nano33BLESenseMagnetometerSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36675A124FE5F5E004E567D /* Nano33BLESenseMagnetometerSensor.swift */; };
 		F36675A424FE9D36004E567D /* Nano33BLESenseBarometricPressureSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36675A324FE9D36004E567D /* Nano33BLESenseBarometricPressureSensor.swift */; };
 		F36675A624FEB18D004E567D /* Nano33BLESenseHumiditySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36675A524FEB18C004E567D /* Nano33BLESenseHumiditySensor.swift */; };
+		F380EC5F256FF0F900C9539D /* Nano33BLESenseResistanceSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F380EC5E256FF0F900C9539D /* Nano33BLESenseResistanceSensor.swift */; };
 		F384EA4024FD82E200E1F1DE /* Nano33BLESenseServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = F384EA3F24FD82E100E1F1DE /* Nano33BLESenseServiceInterface.swift */; };
 		F384EA4224FD834000E1F1DE /* Nano33BLESenseTemperatureSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F384EA4124FD833F00E1F1DE /* Nano33BLESenseTemperatureSensor.swift */; };
 		F389279224DC408900843D1D /* ArduinoColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = F389279124DC408900843D1D /* ArduinoColorPalette.swift */; };
@@ -1502,6 +1503,7 @@
 		F36675A124FE5F5E004E567D /* Nano33BLESenseMagnetometerSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nano33BLESenseMagnetometerSensor.swift; sourceTree = "<group>"; };
 		F36675A324FE9D36004E567D /* Nano33BLESenseBarometricPressureSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nano33BLESenseBarometricPressureSensor.swift; sourceTree = "<group>"; };
 		F36675A524FEB18C004E567D /* Nano33BLESenseHumiditySensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nano33BLESenseHumiditySensor.swift; sourceTree = "<group>"; };
+		F380EC5E256FF0F900C9539D /* Nano33BLESenseResistanceSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nano33BLESenseResistanceSensor.swift; sourceTree = "<group>"; };
 		F384EA3F24FD82E100E1F1DE /* Nano33BLESenseServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nano33BLESenseServiceInterface.swift; sourceTree = "<group>"; };
 		F384EA4124FD833F00E1F1DE /* Nano33BLESenseTemperatureSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nano33BLESenseTemperatureSensor.swift; sourceTree = "<group>"; };
 		F389279124DC408900843D1D /* ArduinoColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArduinoColorPalette.swift; sourceTree = "<group>"; };
@@ -3193,6 +3195,7 @@
 		BC9D3E0E2513B7C3009ACA46 /* Sensors */ = {
 			isa = PBXGroup;
 			children = (
+				F380EC5E256FF0F900C9539D /* Nano33BLESenseResistanceSensor.swift */,
 				F32D236924FEE75900C7E8CE /* Nano33BLESenseColorIlluminanceSensor.swift */,
 				F32D236B24FEECC400C7E8CE /* Nano33BLESenseColorTemperatureSensor.swift */,
 				F32D236724FEDDAB00C7E8CE /* Nano33BLESenseProximitySensor.swift */,
@@ -3988,6 +3991,7 @@
 				5C6CCE3F1FCCCD3A008987F9 /* EditTimestampViewController.swift in Sources */,
 				5C7EFC59202DFFE50007F99E /* GSJOperation.swift in Sources */,
 				8B175C85209D08AC000E2974 /* ExperimentsListItemsViewController.swift in Sources */,
+				F380EC5F256FF0F900C9539D /* Nano33BLESenseResistanceSensor.swift in Sources */,
 				5C72195D1ED8D04700817F0B /* Experiment.swift in Sources */,
 				F36675A624FEB18D004E567D /* Nano33BLESenseHumiditySensor.swift in Sources */,
 				8B5922A11F9E374A0090DB6F /* LocalizedNumberFormatter.swift in Sources */,

--- a/ScienceJournal/BLEArduino/BLEArduinoSensorInterface.swift
+++ b/ScienceJournal/BLEArduino/BLEArduinoSensorInterface.swift
@@ -28,6 +28,9 @@ enum BLEArduinoSensorConfig: Int, Codable {
   case temperatureCelsius
   case temperatureFahrenheit
   case light
+  case resistor1kOhm
+  case resistor10kOhm
+  case resistor1MOhm
 }
 
 protocol BLEArduinoSensor {

--- a/ScienceJournal/BLEArduino/Nano33BLE/Nano33BLESenseServiceInterface.swift
+++ b/ScienceJournal/BLEArduino/Nano33BLE/Nano33BLESenseServiceInterface.swift
@@ -94,6 +94,10 @@ class Nano33BLESenseServiceInterface: BLEServiceInterface {
       return BLEArduinoSensorInterface(spec: spec,
                                        sensor: Nano33BLESenseColorTemperatureSensor(),
                                        serviceId: Nano33BLESenseIds.serviceUUID)
+    case Nano33BLESenseResistanceSensor.identifier:
+      return BLEArduinoSensorInterface(spec: spec,
+                                       sensor: Nano33BLESenseResistanceSensor(),
+                                       serviceId: Nano33BLESenseIds.serviceUUID)
     default:
       return nil
     }
@@ -142,6 +146,9 @@ class Nano33BLESenseServiceInterface: BLEServiceInterface {
                                 serviceId: Nano33BLESenseIds.serviceUUID),
       BLEArduinoSensorInterface(peripheral: peripheral,
                                 sensor: Nano33BLESenseColorTemperatureSensor(),
+                                serviceId: Nano33BLESenseIds.serviceUUID),
+      BLEArduinoSensorInterface(peripheral: peripheral,
+                                sensor: Nano33BLESenseResistanceSensor(),
                                 serviceId: Nano33BLESenseIds.serviceUUID)
     ]
   }

--- a/ScienceJournal/BLEArduino/Nano33BLE/Sensors/Nano33BLESenseResistanceSensor.swift
+++ b/ScienceJournal/BLEArduino/Nano33BLE/Sensors/Nano33BLESenseResistanceSensor.swift
@@ -1,0 +1,69 @@
+//
+//  Nano33BLESenseTemperatureSensor.swift
+//  ScienceJournal
+//
+//  Created by Sebastian Romero on 1/09/2020.
+//  Copyright © 2020 Arduino. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import CoreBluetooth
+
+struct Nano33BLESenseResistanceSensor: BLEArduinoSensor {
+  static var uuid: CBUUID { CBUUID(string: "555a0002-0020-467a-9538-01f0652c74e8") }
+
+  var name: String { "resistance".localized }
+
+  var iconName: String { "ic_sensor_resistance" }
+  
+  var filledIconName: String { "ic_sensor_resistance_filled" }
+
+  var animatingIconName: String { "mkrsci_resistance" }
+
+  var unitDescription: String? { "k\u{03A9}" }
+
+  var textDescription: String { "sensor_desc_short_mkrsci_resistance".localized }
+
+  var learnMoreInformation: Sensor.LearnMore {
+    Sensor.LearnMore(firstParagraph: "",
+                     secondParagraph: "",
+                     imageName: "")
+  }
+
+  var options: [BLEArduinoSensorConfig] = [
+    .resistor1kOhm, .resistor10kOhm, .resistor1MOhm
+  ]
+
+  var config: BLEArduinoSensorConfig? = .resistor10kOhm
+
+  func point(for data: Data) -> Double {
+    guard data.count == 4 else { return 0 }
+    
+    var resistanceR1:Float
+    
+    switch config {
+    case .resistor1kOhm:
+      resistanceR1 = 1000
+    case .resistor10kOhm:
+      resistanceR1 = 10000
+    case .resistor1MOhm:
+      resistanceR1 = 1000000
+    default:
+      resistanceR1 = 10000
+    }
+    
+    let voltageRatio = data.withUnsafeBytes { $0.load(fromByteOffset: 0, as: Float.self) }
+    let resistanceR2 = resistanceR1 * (1 / (voltageRatio - 1))
+    return Double(resistanceR2 / 1000)
+  }
+}

--- a/ScienceJournal/BLEArduino/UI/ScienceKitSensorConfigSelectorView.swift
+++ b/ScienceJournal/BLEArduino/UI/ScienceKitSensorConfigSelectorView.swift
@@ -30,6 +30,12 @@ extension BLEArduinoSensorConfig {
       return "Temperature (Fahrenheit)"
     case .light:
       return "Light"
+    case .resistor1kOhm:
+      return "1kΩ Resistor"
+    case .resistor10kOhm:
+      return "10kΩ Resistor"
+    case .resistor1MOhm:
+      return "1MΩ Resistor"
     }
   }
 
@@ -39,6 +45,8 @@ extension BLEArduinoSensorConfig {
       return UIImage(named: "ic_sensor_temperature")!
     case .light:
       return UIImage(named: "ic_sensor_light")!
+    case .resistor1kOhm, .resistor10kOhm, .resistor1MOhm:
+      return UIImage(named: "ic_sensor_resistance")!
     case .raw:
       return UIImage(named: "ic_sensor_raw")!
     }


### PR DESCRIPTION
This PR adds support for a resistance measurement "sensor" (voltage divider circuit).

### Checklist
- [x] All new and existing tests pass
- [x] I've read the [Contribution Guidelines](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CONTRIBUTING.md)
- [x] I've read [Change Limitations](https://github.com/arduino/Arduino-Science-Journal-iOS/blob/main/CHANGE_LIMITATIONS.md)

### Motivation and Context
To allow the users to measure resistance with their BLE sense board, the app needs to support this.

### Description
Added a new sensor class for resistance to the BLE Sense BLE infrastructure.